### PR TITLE
Implement sparse reward system and reward_mapping attribute

### DIFF
--- a/ourhexenv.py
+++ b/ourhexenv.py
@@ -1,6 +1,7 @@
 import math
 import pygame
 import numpy as np
+from typing import Dict
 from pettingzoo.utils.env import AECEnv
 from gymnasium import spaces
 from pettingzoo.utils import agent_selector
@@ -13,6 +14,17 @@ class OurHexGame(AECEnv):
         super().__init__()
         self.board_size = board_size
         self.sparse_flag = sparse_flag
+        # Initialize reward mapping. Always three keys: WIN, LOSE, MOVE
+        if self.sparse_flag:
+            self.reward_mapping: Dict[str, int] = {
+                "WIN": 1,
+                "LOSE": -1,
+                "MOVE": 0
+            }
+        else:
+            # TODO: Implement as part of https://github.com/sjsu-interconnect/ourhexgame/issues/6
+            self.reward_mapping: Dict[str, int] = {}
+
         self.agents = ["player_1", "player_2"]
         self.agent_selector = agent_selector(self.agents)
         self.agent_selection = self.agent_selector.next()
@@ -91,12 +103,14 @@ class OurHexGame(AECEnv):
 
             if self.check_winner(marker):
                 self.terminations = {agent: True for agent in self.agents}
+                win_r, lose_r = self.reward_mapping["WIN"], self.reward_mapping["LOSE"]
                 self.rewards = {
-                    agent: 10 if agent == self.agent_selection else -10
+                    agent: win_r if agent == self.agent_selection else lose_r
                     for agent in self.agents
                 }
             else:
-                self.rewards = {agent: -1 for agent in self.agents}
+                move_r = self.reward_mapping["MOVE"]
+                self.rewards = {agent: move_r for agent in self.agents}
                 self.terminations = {agent: False for agent in self.agents}
 
         if self.agent_selection == "player_2":


### PR DESCRIPTION
The following patch implements a single entry point for the reward system as a dictionary in the reward_mapping attribute. Depending on whether the sparse_flag is true or not, a dense reward or a sparse reward mapping can be defined.

This patch only defines the sparse reward system. Follow-up work on the dense reward to be implemented as part of: https://github.com/sjsu-interconnect/ourhexgame/issues/6

Callers that used a hardcoded reward have also been updated to look up an appropriate reward in the reward_mapping instead.