### PR TITLE
fix: update observe() method to include pie rule status

### DIFF
--- a/ourhexenv.py
+++ b/ourhexenv.py
@@ -118,7 +118,10 @@ class OurHexGame(AECEnv):
         self.agent_selection = self.agent_selector.next()
 
     def observe(self, agent):
-        return self.board
+        return {
+            "observation": self.board,
+            "pie_rule_used": 1 if self.is_pie_rule_usable else 0
+        }
 
 
     def _get_hex_points(self, x, y):


### PR DESCRIPTION
The observe() method previously only returned the board state (self.board). However, as per the requirements derived from Issue #1, the method needs to include the pie rule status (pie_rule_used) to provide complete observation information. This ensures agents are aware of whether the pie rule has been used during the game.