### PR TITLE
Update ourhexenv.py to be able to pass pettingzoo's api test

### DIFF
--- a/ourhexenv.py
+++ b/ourhexenv.py
@@ -161,7 +161,6 @@ class OurHexGame(AECEnv):
         self.is_first = True
         self.is_pie_rule_usable = True
         self.is_pie_rule_used = False
-        self.agent_selection = "player_1"
 
         self.dones = {agent: False for agent in self.agents}
         self.infos = {agent: self.generate_info(agent) for agent in self.agents}


### PR DESCRIPTION
Given that we are using AECenv, it is reasonable to adhere to the API enforced by AECEnv. Pettingzoo's api_test works as a smoke test in two ways:

1) It enforces the pettingzoo API
2) It automatically "plays" with the environment
for a couple of rounds.

Point 2) is perhaps the most powerful of all, as it is a free game played directly with the environment. The following patch fixes a couple of bugs. Namely,

i) The info dictionary should always pass valid information. There was a bug where infos was set to empty dicts in reset causing the first calls of env.last() to be inaccurate. There was also a bug where the infos were not being recomputed after step, causing the action_mask to not represent the state of the board.

ii) Fixes agent_selector logic. Agent selector binds to a list in the form of a stack/queue. Therefore, after reset/init we have to re-create a new self.agents such that agent selector works consistently. This patch fixes that.

iii) Environment's game is automatically played
using env.iter_agents. In order for this API
to be consistenty, we have to handle "dead" agents. Please see how this is handled in the step function.

iv) reset should take both a seed and options, enforced by the Pettingzoo API.

Fixes: https://github.com/sjsu-interconnect/ourhexgame/issues/34