### PR TITLE
Return a copy of the board in the observe method

### DIFF
--- a/ourhexenv.py
+++ b/ourhexenv.py
@@ -301,7 +301,7 @@ class OurHexGame(AECEnv):
 
     def observe(self, agent):
         return {
-            "observation": self.board,
+            "observation": self.board.copy(),
             "pie_rule_used": 1 if self.is_pie_rule_used else 0,
         }
 


### PR DESCRIPTION
We are only returning the self.board using the observe method.

This is a bug in the environment. Why? Assume the agent holds the observation from the first step. In the third step, the observation from the first step (held by the agent) will mutate to reflect the state of the board at the third step. This is undesired behavior.

The fix will be to return a simple .copy version of the board in the observe method

Fixes: https://github.com/sjsu-interconnect/ourhexgame/issues/41